### PR TITLE
APIs + Compilation Cache + Local Source Watcher

### DIFF
--- a/src/Diagnostics.DataProviders/ConfigurationFactory.cs
+++ b/src/Diagnostics.DataProviders/ConfigurationFactory.cs
@@ -10,7 +10,7 @@ namespace Diagnostics.DataProviders
 {
     public interface IConfigurationFactory
     {
-        //KustoDataProviderConfiguration GetKustoConfiguration();
+        DataSourcesConfiguration LoadConfigurations();
     }
 
     public class AppSettingsDataProviderConfigurationFactory : DataProviderConfigurationFactory

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -19,10 +19,9 @@ namespace Diagnostics.DataProviders
             _kustoClient = KustoClientFactory.GetKustoClient(configuration);
         }
 
-        public async Task<DataTableResponseObject> ExecuteQuery(string query, string stampName)
+        public async Task<DataTableResponseObject> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null)
         {
-            return await _kustoClient.ExecuteQueryAsync(query, stampName);
-            
+            return await _kustoClient.ExecuteQueryAsync(query, stampName, requestId, operationName);
         }
     }
 }

--- a/src/Diagnostics.DataProviders/DataTableUtility.cs
+++ b/src/Diagnostics.DataProviders/DataTableUtility.cs
@@ -5,9 +5,9 @@ using System.Linq;
 
 namespace Diagnostics.DataProviders
 {
-    internal static class DataTableUtility
+    public static class DataTableUtility
     {
-        internal static DataTable GetDataTable(DataTableResponseObject dataTableResponse)
+        public static DataTable GetDataTable(DataTableResponseObject dataTableResponse)
         {
             if (dataTableResponse == null)
             {

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
@@ -8,6 +8,6 @@ namespace Diagnostics.DataProviders
 {
     public interface IKustoClient
     {
-        Task<DataTableResponseObject> ExecuteQueryAsync(string query, string stampName, string requestId = null);
+        Task<DataTableResponseObject> ExecuteQueryAsync(string query, string stampName, string requestId = null, string operationName = null);
     }
 }

--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -43,7 +43,7 @@ namespace Diagnostics.DataProviders
             _configuration = configuration;
         }
 
-        public async Task<DataTableResponseObject> ExecuteQueryAsync(string query, string stampName, string requestId = null)
+        public async Task<DataTableResponseObject> ExecuteQueryAsync(string query, string stampName, string requestId = null, string operationName = null)
         {
             string appserviceRegion = ParseRegionFromStamp(stampName);
 

--- a/src/Diagnostics.DataProviders/MockKustoClient.cs
+++ b/src/Diagnostics.DataProviders/MockKustoClient.cs
@@ -8,8 +8,20 @@ namespace Diagnostics.DataProviders
 {
     class MockKustoClient: IKustoClient
     {
-        public async Task<DataTableResponseObject> ExecuteQueryAsync(string query, string stampName, string requestId = null)
+        public async Task<DataTableResponseObject> ExecuteQueryAsync(string query, string stampName, string requestId = null, string operationName = null)
         {
+            if (!string.IsNullOrWhiteSpace(operationName))
+            {
+                switch (operationName.ToLower())
+                {
+                    case "gettenantidforstamp":
+                        return await GetFakeTenantIdResults();
+
+                    default:
+                        return await GetTestA();
+                }
+            }
+
             switch(query)
             {
                 case "TestA":
@@ -17,6 +29,29 @@ namespace Diagnostics.DataProviders
             }
 
             return new DataTableResponseObject();
+        }
+
+        private Task<DataTableResponseObject> GetFakeTenantIdResults()
+        {
+            var tenantColumn = new DataTableResponseColumn();
+            tenantColumn.ColumnName = "Tenant";
+            tenantColumn.ColumnType = "string";
+            tenantColumn.DataType = "String";
+
+            var publicHostColumn = new DataTableResponseColumn();
+            publicHostColumn.ColumnName = "PublicHost";
+            publicHostColumn.ColumnType = "string";
+            publicHostColumn.DataType = "String";
+
+            var res = new DataTableResponseObject
+            {
+                Columns = new List<DataTableResponseColumn>(new[] { tenantColumn, publicHostColumn })
+            };
+
+            res.Rows = new string[1][];
+            res.Rows[0] = new string[2] { Guid.NewGuid().ToString(), "fakestamp.cloudapp.net" };
+            
+            return Task.FromResult(res);
         }
 
         private Task<DataTableResponseObject> GetTestA()

--- a/src/Diagnostics.ScriptHost/CacheService/CompilationCache.cs
+++ b/src/Diagnostics.ScriptHost/CacheService/CompilationCache.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Diagnostics.ScriptHost
+{
+    public class CompilationCache<K, V> : ICacheService<K, V>
+    {
+        private ConcurrentDictionary<K, V> _collection;
+
+        public CompilationCache()
+        {
+            _collection = new ConcurrentDictionary<K, V>();
+        }
+
+        public void AddOrUpdate(K key, V value)
+        {
+            _collection.AddOrUpdate(key, value, (existingKey, oldValue) => value);
+        }
+
+        public bool TryGetValue(K key, out V value)
+        {
+            return _collection.TryGetValue(key, out value);
+        }
+
+        public bool RemoveValue(K key, out V value)
+        {
+            return _collection.TryRemove(key, out value);
+        }
+
+        public IEnumerable<V> GetAll()
+        {
+            return _collection.Values;
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/CacheService/ICacheService.cs
+++ b/src/Diagnostics.ScriptHost/CacheService/ICacheService.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Diagnostics.ScriptHost
+{
+    public interface ICacheService<K, V>
+    {
+        void AddOrUpdate(K key, V value);
+
+        bool TryGetValue(K key, out V value);
+
+        bool RemoveValue(K key, out V value);
+
+        IEnumerable<V> GetAll();
+    }
+}

--- a/src/Diagnostics.ScriptHost/Controllers/ControllerBase.cs
+++ b/src/Diagnostics.ScriptHost/Controllers/ControllerBase.cs
@@ -1,0 +1,71 @@
+﻿using Diagnostics.ScriptHost.DataProviderServices;
+using Diagnostics.ScriptHost.Models;
+using Diagnostics.ScriptHost.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Diagnostics.ScriptHost.Controllers
+{
+    public abstract class ControllerBase : Controller
+    {
+        public ControllerBase()
+        {
+        }
+    }
+
+    public abstract class SiteControllerBase : ControllerBase
+    {
+        private ITenantIdService _tenantIdService;
+
+        public SiteControllerBase(ITenantIdService tenantIdService)
+        {
+            _tenantIdService = tenantIdService;
+        }
+
+        protected bool VerifyQueryParams(string[] hostNames, string stampName, out string reason)
+        {
+            reason = string.Empty;
+            if (hostNames == null || hostNames.Length <= 0)
+            {
+                reason = "Invalid or empty hostnames";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(stampName))
+            {
+                reason = "Invalid or empty stampName";
+                return false;
+            }
+
+            return true;
+        }
+        
+        protected async Task<SiteResource> PrepareResourceObject(string subscriptionId, string resourceGroup, string siteName, IEnumerable<string> hostNames, string stampName, DateTime startTime, DateTime endTime, string sourceMoniker = null)
+        {
+            List<string> tenantIdList = await _tenantIdService.GetTenantIdForStamp(stampName, startTime, endTime);
+            SiteResource resource = new SiteResource()
+            {
+                SubscriptionId = subscriptionId,
+                ResourceGroup = resourceGroup,
+                SiteName = siteName,
+                HostNames = hostNames,
+                Stamp = stampName,
+                SourceMoniker = sourceMoniker ?? stampName.ToUpper().Replace("-", string.Empty),
+                TenantIdList = tenantIdList
+            };
+
+            return resource;
+        }
+
+        protected OperationContext PrepareContext(SiteResource resource, DateTime startTime, DateTime endTime)
+        {
+            return new OperationContext(
+                resource,
+                DateTimeHelper.GetDateTimeInUtcFormat(startTime).ToString(HostConstants.KustoTimeFormat),
+                DateTimeHelper.GetDateTimeInUtcFormat(endTime).ToString(HostConstants.KustoTimeFormat)
+            );
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Controllers/ProcessHealthController.cs
+++ b/src/Diagnostics.ScriptHost/Controllers/ProcessHealthController.cs
@@ -1,19 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Data;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using Diagnostics.DataProviders;
-using Diagnostics.ScriptHost.Models;
-using Diagnostics.ScriptHost.Utilities;
-using Diagnostics.Scripts;
-using Diagnostics.Scripts.Models;
-using Microsoft.AspNetCore.Http;
+﻿using Diagnostics.ScriptHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Diagnostics.ScriptHost.Controllers
 {

--- a/src/Diagnostics.ScriptHost/Controllers/SitesController.cs
+++ b/src/Diagnostics.ScriptHost/Controllers/SitesController.cs
@@ -1,26 +1,75 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Data;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using Diagnostics.DataProviders;
+﻿using Diagnostics.ScriptHost.DataProviderServices;
 using Diagnostics.ScriptHost.Models;
+using Diagnostics.ScriptHost.SourceWatcher.Interfaces;
 using Diagnostics.ScriptHost.Utilities;
 using Diagnostics.Scripts;
 using Diagnostics.Scripts.Models;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Diagnostics.ScriptHost.Controllers
 {
     [Produces("application/json")]
     [Route(UriElements.SitesResource + UriElements.Diagnostics)]
-    public class SitesController : Controller
+    public class SitesController : SiteControllerBase
     {
+        private IDataSourcesConfigurationService _dataSourcesConfigService;
+        private ICacheService<string, Tuple<Definition, EntityInvoker>> _compilationCacheService;
+        private ISourceWatcher _sourceWatcherService;
+        private ITenantIdService _tenantIdService;
+
+        public SitesController(IDataSourcesConfigurationService dataSourcesConfigService, ICacheService<string, Tuple<Definition, EntityInvoker>> compilationCache, ISourceWatcher sourceWatcher, ITenantIdService tenantIdService)
+            :base(tenantIdService)
+        {
+            _compilationCacheService = compilationCache;
+            _dataSourcesConfigService = dataSourcesConfigService;
+            _sourceWatcherService = sourceWatcher;
+            _tenantIdService = tenantIdService;
+        }
+
+        [HttpGet(UriElements.Detectors)]
+        public async Task<IActionResult> ListDetectors(string subscriptionId, string resourceGroupName, string siteName)
+        {
+            await _sourceWatcherService.WaitForCompletion();
+            IEnumerable<Definition> entityDefinitions = _compilationCacheService.GetAll().Select(p => p.Item1);
+            return Ok(entityDefinitions);
+        }
+
+        [HttpGet(UriElements.Detectors + UriElements.DetectorResource)]
+        public async Task<IActionResult> GetDetectorResource(string subscriptionId, string resourceGroupName, string siteName, string detectorId, string[] hostNames, string stampName, string startTime = null, string endTime = null, string timeGrain = null)
+        {
+            if (!VerifyQueryParams(hostNames, stampName, out string verficationOutput))
+            {
+                return BadRequest(verficationOutput);
+            }
+
+            if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))
+            {
+                return BadRequest(errorMessage);
+            }
+
+            await _sourceWatcherService.WaitForCompletion();
+
+            if (!_compilationCacheService.TryGetValue(detectorId.ToLower(), out Tuple<Definition, EntityInvoker> entity))
+            {
+                return NotFound($"No entity found with detector Id : {detectorId.ToLower()}");
+            }
+
+            EntityInvoker invoker = entity.Item2;
+            var dataProviders = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
+            SiteResource resource = await PrepareResourceObject(subscriptionId, resourceGroupName, siteName, hostNames, stampName, startTimeUtc, endTimeUtc);
+            OperationContext cxt = PrepareContext(resource, startTimeUtc, endTimeUtc);
+
+            SignalResponse res = new SignalResponse();
+            res = (SignalResponse)await invoker.Invoke(new object[] { dataProviders, cxt, res });
+            res.Metadata = AttributeHelper.CreateDefinitionAttribute(invoker.Attributes.FirstOrDefault());
+            return Ok(res);
+        }
+
         [HttpPost(UriElements.Query)]
         public async Task<IActionResult> Post(string subscriptionId, string resourceGroupName, string siteName, string[] hostNames, string stampName, [FromBody]JToken jsonBody, string startTime = null, string endTime = null, string timeGrain = null)
         {
@@ -36,58 +85,27 @@ namespace Diagnostics.ScriptHost.Controllers
                 return BadRequest("Missing script from body");
             }
 
-            if (hostNames == null || hostNames.Length <= 0)
+            if (!VerifyQueryParams(hostNames, stampName, out string verficationOutput))
             {
-                return BadRequest("Invalid or empty hostnames");
+                return BadRequest(verficationOutput);
             }
-
-            if (string.IsNullOrWhiteSpace(stampName))
-            {
-                return BadRequest("Invalid or empty stampName");
-            }
-
-            DateTime startTimeUtc, endTimeUtc;
-            TimeSpan timeGrainTimeSpan;
-            string errorMessage;
-
-            if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out startTimeUtc, out endTimeUtc, out timeGrainTimeSpan, out errorMessage))
+            
+            if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))
             {
                 return BadRequest(errorMessage);
             }
 
-            EntityMetadata metaData = new EntityMetadata()
-            {
-                Name = "On Demand Query",
-                scriptText = script,
-                Type = EntityType.Signal
-            };
-
-            // TODO : We want to get DataProvider or config based on Environment (dev or prod)
-            //var configFactory = new AppSettingsDataProviderConfigurationFactory();
-            var configFactory = new RegistryDataProviderConfigurationFactory(HostConstants.RegistryRootPath);
-            var config = configFactory.LoadConfigurations();
-            var dataProviders = new DataProviders.DataProviders(config);
-            
-            SiteResource resource = new SiteResource()
-            {
-                SubscriptionId = subscriptionId,
-                ResourceGroup = resourceGroupName,
-                SiteName = siteName,
-                HostNames = hostNames,
-                Stamp = stampName
-                // TODO : Fill in Tenant
-            };
-
-            OperationContext cxt = new OperationContext(
-                resource,
-                DateTimeHelper.GetDateTimeInUtcFormat(startTimeUtc).ToString(HostConstants.KustoTimeFormat),
-                DateTimeHelper.GetDateTimeInUtcFormat(endTimeUtc).ToString(HostConstants.KustoTimeFormat)
-            );
+            EntityMetadata metaData = new EntityMetadata(script);
+            var dataProviders = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
+            SiteResource resource = await PrepareResourceObject(subscriptionId, resourceGroupName, siteName, hostNames, stampName, startTimeUtc, endTimeUtc);
+            OperationContext cxt = PrepareContext(resource, startTimeUtc, endTimeUtc);
 
             using (var invoker = new EntityInvoker(metaData, ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports()))
             {
-                QueryResponse<SignalResponse> response = new QueryResponse<SignalResponse>();
-                response.InvocationOutput = new SignalResponse();
+                QueryResponse<SignalResponse> response = new QueryResponse<SignalResponse>
+                {
+                    InvocationOutput = new SignalResponse()
+                };
 
                 try
                 {
@@ -95,7 +113,7 @@ namespace Diagnostics.ScriptHost.Controllers
                     response.CompilationSucceeded = invoker.IsCompilationSuccessful;
                     response.CompilationOutput = invoker.CompilationOutput;
                     response.InvocationOutput = (SignalResponse)await invoker.Invoke(new object[] { dataProviders, cxt, response.InvocationOutput });
-                    
+                    response.InvocationOutput.Metadata = AttributeHelper.CreateDefinitionAttribute(invoker.Attributes.FirstOrDefault());
                     return Ok(response);
                 }
                 catch(Exception ex)

--- a/src/Diagnostics.ScriptHost/DataProviderServices/DataSourcesConfigurationService.cs
+++ b/src/Diagnostics.ScriptHost/DataProviderServices/DataSourcesConfigurationService.cs
@@ -1,0 +1,25 @@
+﻿using Diagnostics.DataProviders;
+using Diagnostics.ScriptHost.Utilities;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Diagnostics.ScriptHost.DataProviderServices
+{
+
+    public interface IDataSourcesConfigurationService
+    {
+        DataSourcesConfiguration Config { get; }
+    }
+
+    public class DataSourcesConfigurationService : IDataSourcesConfigurationService
+    {
+        private DataSourcesConfiguration _config;
+
+        public DataSourcesConfiguration Config => _config;
+
+        public DataSourcesConfigurationService(IHostingEnvironment env)
+        {
+            IConfigurationFactory factory = DataProviderHelper.GetDataProviderConfigurationFactory(env);
+            _config = factory.LoadConfigurations();
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/DataProviderServices/TenantIdService.cs
+++ b/src/Diagnostics.ScriptHost/DataProviderServices/TenantIdService.cs
@@ -1,0 +1,70 @@
+﻿using Diagnostics.DataProviders;
+using Diagnostics.ScriptHost.Utilities;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+
+namespace Diagnostics.ScriptHost.DataProviderServices
+{
+    public interface ITenantIdService
+    {
+        Task<List<string>> GetTenantIdForStamp(string stamp, DateTime startTime, DateTime endTime, string requestId = null);
+    }
+
+    public class TenantIdService : ITenantIdService
+    {
+        private ConcurrentDictionary<string, List<string>> _tenantCache;
+        private string _queryTemplate;
+        private IDataSourcesConfigurationService _dataSourcesConfigService;
+
+        public TenantIdService(IDataSourcesConfigurationService dataSourcesConfigService)
+        {
+            _dataSourcesConfigService = dataSourcesConfigService;
+            _tenantCache = new ConcurrentDictionary<string, List<string>>();
+            _queryTemplate =
+            @"RoleInstanceHeartbeat
+              | where TIMESTAMP >= datetime({StartTime}) and TIMESTAMP <= datetime({EndTime}) and PublicHost startswith ""{StampName}""
+              | summarize by Tenant, PublicHost";
+        }
+
+        public async Task<List<string>> GetTenantIdForStamp(string stamp, DateTime startTime, DateTime endTime, string requestId = null)
+        {
+            if (string.IsNullOrWhiteSpace(stamp))
+            {
+                throw new ArgumentNullException("stamp cannot be null.");
+            }
+
+            if (_tenantCache.TryGetValue(stamp.ToLower(), out List<string> tenantIds))
+            {
+                return tenantIds;
+            }
+
+            tenantIds = new List<string>();
+            string startTimeStr = DateTimeHelper.GetDateTimeInUtcFormat(startTime).ToString(HostConstants.KustoTimeFormat);
+            string endTimeStr = DateTimeHelper.GetDateTimeInUtcFormat(endTime).ToString(HostConstants.KustoTimeFormat);
+
+            var query = _queryTemplate
+                .Replace("{StartTime}", startTimeStr)
+                .Replace("{EndTime}", endTimeStr)
+                .Replace("{StampName}", stamp);
+
+            DataProviders.DataProviders dp = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
+            DataTableResponseObject response = await dp.Kusto.ExecuteQuery(query, stamp, requestId, "GetTenantIdForStamp");
+            DataTable tenantIdTable = DataTableUtility.GetDataTable(response);
+
+            if (tenantIdTable != null && tenantIdTable.Rows.Count > 0)
+            {
+                foreach (DataRow row in tenantIdTable.Rows)
+                {
+                    tenantIds.Add(row["Tenant"].ToString());
+                }
+
+                _tenantCache.TryAdd(stamp, tenantIds);
+            }
+
+            return tenantIds;
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Diagnostics.ScriptHost.csproj
+++ b/src/Diagnostics.ScriptHost/Diagnostics.ScriptHost.csproj
@@ -5,13 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="SourceWatcher\BlobStorage\**" />
-    <Content Remove="SourceWatcher\BlobStorage\**" />
-    <EmbeddedResource Remove="SourceWatcher\BlobStorage\**" />
-    <None Remove="SourceWatcher\BlobStorage\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/src/Diagnostics.ScriptHost/Diagnostics.ScriptHost.csproj
+++ b/src/Diagnostics.ScriptHost/Diagnostics.ScriptHost.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Folder Include="SourceWatcher\BlobStorage\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/src/Diagnostics.ScriptHost/Diagnostics.ScriptHost.csproj
+++ b/src/Diagnostics.ScriptHost/Diagnostics.ScriptHost.csproj
@@ -5,7 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="SourceWatcher\BlobStorage\" />
+    <Compile Remove="SourceWatcher\BlobStorage\**" />
+    <Content Remove="SourceWatcher\BlobStorage\**" />
+    <EmbeddedResource Remove="SourceWatcher\BlobStorage\**" />
+    <None Remove="SourceWatcher\BlobStorage\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/src/Diagnostics.ScriptHost/Models/Definition.cs
+++ b/src/Diagnostics.ScriptHost/Models/Definition.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Diagnostics.ScriptHost.Models
+{
+    public class Definition : Attribute, IEquatable<Definition>
+    {
+        [DataMember]
+        public string Id { get; set; }
+
+        [DataMember]
+        public string Name { get; set; }
+
+        [DataMember]
+        public string Description { get; set; }
+
+        public bool Equals(Definition other)
+        {
+            return this.Id == other.Id;
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Models/OperationContext.cs
+++ b/src/Diagnostics.ScriptHost/Models/OperationContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Diagnostics.ScriptHost.Utilities;
 
 namespace Diagnostics.ScriptHost.Models
 {
@@ -13,11 +10,14 @@ namespace Diagnostics.ScriptHost.Models
 
         public string EndTime;
 
+        public string TimeGrain;
+
         public OperationContext(SiteResource resource, string startTimeStr, string endTimeStr)
         {
             Resource = resource;
             StartTime = startTimeStr;
             EndTime = endTimeStr;
+            TimeGrain = HostConstants.DefaultTimeGrainInMinutes.ToString();
         }
     }
 }

--- a/src/Diagnostics.ScriptHost/Models/QueryResponse.cs
+++ b/src/Diagnostics.ScriptHost/Models/QueryResponse.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Diagnostics.ScriptHost.Models
 {

--- a/src/Diagnostics.ScriptHost/Models/Resource.cs
+++ b/src/Diagnostics.ScriptHost/Models/Resource.cs
@@ -1,26 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Diagnostics.ScriptHost.Models
 {
-    public class Resource
+    public interface IResource
     {
     }
 
-    public class SiteResource
+    public abstract class Resource : IResource
     {
         public string SubscriptionId;
 
         public string ResourceGroup;
 
+        public IEnumerable<string> TenantIdList;
+    }
+
+    public sealed class SiteResource : Resource
+    {
         public string SiteName;
 
         public IEnumerable<string> HostNames;
 
         public string Stamp;
 
-        public string TenantId;
+        public string SourceMoniker;
     }
 }

--- a/src/Diagnostics.ScriptHost/Models/SignalResponse.cs
+++ b/src/Diagnostics.ScriptHost/Models/SignalResponse.cs
@@ -1,19 +1,17 @@
 ﻿using Diagnostics.DataProviders;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Diagnostics.ScriptHost.Models
 {
     public class SignalResponse
     {
-        public SignalMetaData Metadata { get; set; }
+        public Definition Metadata { get; set; }
 
         public List<DiagnosticData> Dataset { get; set; }
 
         public SignalResponse()
         {
-            Metadata = new SignalMetaData();
+            Metadata = new Definition();
             Dataset = new List<DiagnosticData>();
         }
     }
@@ -29,15 +27,6 @@ namespace Diagnostics.ScriptHost.Models
             Table = new DataTableResponseObject();
             RenderingProperties = new Rendering();
         }
-    }
-
-    public class SignalMetaData
-    {
-        public string Id { get; set; }
-
-        public string Name { get; set; }
-
-        public string Description { get; set; }
     }
 
     public class Rendering

--- a/src/Diagnostics.ScriptHost/Models/SourceWatcherType.cs
+++ b/src/Diagnostics.ScriptHost/Models/SourceWatcherType.cs
@@ -1,0 +1,9 @@
+﻿namespace Diagnostics.ScriptHost.Models
+{
+    public enum SourceWatcherType
+    {
+        LocalFileSystem = 0,
+        BlobStorage = 1,
+        Github = 2
+    }
+}

--- a/src/Diagnostics.ScriptHost/Program.cs
+++ b/src/Diagnostics.ScriptHost/Program.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Diagnostics.ScriptHost
 {

--- a/src/Diagnostics.ScriptHost/SourceWatcher/Interfaces/ISourceWatcher.cs
+++ b/src/Diagnostics.ScriptHost/SourceWatcher/Interfaces/ISourceWatcher.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Diagnostics.ScriptHost.SourceWatcher.Interfaces
+{
+    public interface ISourceWatcher
+    {
+        Task WaitForCompletion();
+    }
+}

--- a/src/Diagnostics.ScriptHost/SourceWatcher/LocalFileSystem/LocalFileSystemSourceWatcherService.cs
+++ b/src/Diagnostics.ScriptHost/SourceWatcher/LocalFileSystem/LocalFileSystemSourceWatcherService.cs
@@ -1,0 +1,82 @@
+﻿using Diagnostics.ScriptHost.Models;
+using Diagnostics.ScriptHost.SourceWatcher.Interfaces;
+using Diagnostics.ScriptHost.Utilities;
+using Diagnostics.Scripts;
+using Diagnostics.Scripts.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Win32;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Diagnostics.ScriptHost.SourceWatcher
+{
+    public class LocalFileSystemSourceWatcherService : ISourceWatcher
+    {
+        private ICacheService<string, Tuple<Definition, EntityInvoker>> _cacheService;
+        private SourceWatcherConfiguration _sourceConfig;
+        private Task _completionTask;
+
+        public LocalFileSystemSourceWatcherService(IHostingEnvironment env, IConfiguration configuration, ICacheService<string, Tuple<Definition, EntityInvoker>> cacheService)
+        {
+            _cacheService = cacheService;
+
+            _sourceConfig = new SourceWatcherConfiguration();
+            if (env.IsProduction())
+            {
+                _sourceConfig.LocalSourceDirectory = (string)Registry.GetValue(HostConstants.ScriptSourceConfigRegistryRootPath, HostConstants.LocalSourceDirectoryKey, string.Empty);
+            }
+            else
+            {
+                _sourceConfig.LocalSourceDirectory = (configuration[$"ScriptSourceConfig:{HostConstants.LocalSourceDirectoryKey}"]).ToString();
+            }
+
+            Start();
+        }
+        
+        private async Task ListFilesAndCompile() {
+
+            foreach (string filename in Directory.EnumerateFiles(_sourceConfig.LocalSourceDirectory))
+            {
+                try
+                {
+                    var fileContent = await File.ReadAllTextAsync(filename);
+                    EntityMetadata metaData = new EntityMetadata()
+                    {
+                        Type = EntityType.Signal,
+                        ScriptText = fileContent
+                    };
+
+                    EntityInvoker invoker = new EntityInvoker(metaData, ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports());
+                    await invoker.InitializeEntryPointAsync();
+
+                    Definition definition = null;
+                    if (invoker.IsCompilationSuccessful)
+                    {
+                        definition = AttributeHelper.CreateDefinitionAttribute(invoker.Attributes.FirstOrDefault());
+                        _cacheService.AddOrUpdate(definition.Id.ToLower(), new Tuple<Definition, EntityInvoker>(definition, invoker));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if(!(ex is ScriptCompilationException))
+                    {
+                        throw ex;
+                    }
+                }
+            }
+        }
+
+        private void Start()
+        {
+            _completionTask = ListFilesAndCompile();
+        }
+
+        public Task WaitForCompletion()
+        {
+            return _completionTask;
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/SourceWatcher/SourceWatcherConfiguration.cs
+++ b/src/Diagnostics.ScriptHost/SourceWatcher/SourceWatcherConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace Diagnostics.ScriptHost.SourceWatcher
+{
+    public class SourceWatcherConfiguration
+    {
+        public string LocalSourceDirectory { get; set; }
+
+        public SourceWatcherConfiguration()
+        {
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/SourceWatcher/SourceWatcherFactory.cs
+++ b/src/Diagnostics.ScriptHost/SourceWatcher/SourceWatcherFactory.cs
@@ -1,0 +1,15 @@
+﻿using Diagnostics.ScriptHost.Models;
+using Diagnostics.ScriptHost.SourceWatcher.Interfaces;
+using System;
+
+namespace Diagnostics.ScriptHost.SourceWatcher
+{
+    public class SourceWatcherFactory
+    {
+        public static ISourceWatcher CreateSourceWatcher(SourceWatcherType type)
+        {
+            // This would be needed when we support mulitple source watchers.
+            throw new NotImplementedException(); 
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Utilities/AttributeHelper.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/AttributeHelper.cs
@@ -1,0 +1,24 @@
+﻿using Diagnostics.ScriptHost.Models;
+using Microsoft.CodeAnalysis;
+using System.Linq;
+
+namespace Diagnostics.ScriptHost.Utilities
+{
+    internal class AttributeHelper
+    {
+        public static Definition CreateDefinitionAttribute(AttributeData attr)
+        {
+            // TODO : Maybe there is a better way to create class object using  attr.AttributeClass (INamedTypeSymbol)
+            // Need to explore that. Right now, a poor man solution below
+
+            var def = new Definition
+            {
+                Name = attr.NamedArguments.Where(p => p.Key == "Name").FirstOrDefault().Value.Value.ToString(),
+                Id = attr.NamedArguments.Where(p => p.Key == "Id").FirstOrDefault().Value.Value.ToString(),
+                Description = attr.NamedArguments.Where(p => p.Key == "Description").FirstOrDefault().Value.Value.ToString()
+            };
+
+            return def;
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Utilities/DataProviderHelper.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/DataProviderHelper.cs
@@ -1,0 +1,60 @@
+﻿using Diagnostics.DataProviders;
+using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Diagnostics.ScriptHost.Utilities
+{
+    internal class DataProviderHelper
+    {
+        public static IConfigurationFactory GetDataProviderConfigurationFactory(IHostingEnvironment env)
+        {
+            if (env.IsProduction())
+            {
+                return new RegistryDataProviderConfigurationFactory(HostConstants.RegistryRootPath);
+            }
+
+
+            switch (env.EnvironmentName.ToLower())
+            {
+                case "mock":
+                    return new MockDataProviderConfigurationFactory();
+                default:
+                    return new AppSettingsDataProviderConfigurationFactory();
+            }
+        }
+
+        public static IEnumerable<string> FilterHostnamesCoveredByWildcard(IEnumerable<string> hostNames)
+        {
+            if (hostNames == null || !hostNames.Any())
+            {
+                return hostNames;
+            }
+
+            //Find if hostnames have a wild card hostname
+            var wildcardHostname = hostNames.Where(p => p.StartsWith("*")).FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(wildcardHostname))
+            {
+                // No wildcard hostnames found.
+                return hostNames;
+            }
+
+            //remove * from the wildcard hostname
+            wildcardHostname = wildcardHostname.Replace("*", string.Empty);
+            var filteredHostnames = new List<string>();
+
+            foreach (var hostname in hostNames)
+            {
+                if (hostname.StartsWith("*") || !hostname.EndsWith(wildcardHostname, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Add this hostname as it is not covered by Wildcard hostname
+                    filteredHostnames.Add(hostname);
+                }
+            }
+
+            return filteredHostnames.ToArray();
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Utilities/DateTimeHelper.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/DateTimeHelper.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Diagnostics.ScriptHost.Utilities
 {
-    public class DateTimeHelper
+    internal class DateTimeHelper
     {
         public static bool PrepareStartEndTimeWithTimeGrain(string startTime, string endTime, string timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage)
         {

--- a/src/Diagnostics.ScriptHost/Utilities/FwUtilities.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/FwUtilities.cs
@@ -1,0 +1,43 @@
+﻿using Diagnostics.ScriptHost.Models;
+using System.Linq;
+
+namespace Diagnostics.ScriptHost.Utilities
+{
+    public class FwUtilities
+    {
+        public static string TimeFilterQuery(OperationContext cxt, string timeColumnName = "PreciseTimeStamp")
+        {
+            return $"{timeColumnName} >= datetime({cxt.StartTime}) and {timeColumnName} <= datetime({cxt.EndTime})";
+        }
+
+        public static string TenantFilterQuery(OperationContext cxt)
+        {
+            return $"Tenant in ({string.Join(",", cxt.Resource.TenantIdList.Select(t => $@"""{t}"""))})";
+        }
+
+        public static string TimeAndTenantFilterQuery(OperationContext cxt, string timeColumnName = "PreciseTimeStamp")
+        {
+            return $"{TimeFilterQuery(cxt, timeColumnName)} and {TenantFilterQuery(cxt)}";
+        }
+
+        public static string HostNamesFilterQuery(OperationContext cxt, string hostNameColumn = "Cs_host")
+        {
+            var wildCardHostNames = cxt.Resource.HostNames.Where(p => p.StartsWith("*"));
+            var nonWildCardHostNames = cxt.Resource.HostNames.Where(p => !p.StartsWith("*"));
+
+            string hostNameQuery = string.Empty;
+
+            if (nonWildCardHostNames.Any()) {
+                hostNameQuery = $"{hostNameColumn} in ({string.Join(",", nonWildCardHostNames.Select(h => $@"""{h}"""))})";
+            }
+
+            if (wildCardHostNames.Any())
+            {
+                string wildCardQuery = string.Join("or", wildCardHostNames.Select(w => $@"{hostNameColumn} endswith ""{w}"""));
+                hostNameQuery = $"{hostNameQuery} or {wildCardQuery}";
+            }
+
+            return hostNameQuery;
+        }
+    }
+}

--- a/src/Diagnostics.ScriptHost/Utilities/HostConstants.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/HostConstants.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Diagnostics.ScriptHost.Utilities
 {
-    public class HostConstants
+    internal class HostConstants
     {
         public const string RegistryRootPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\IIS Extensions\Web Hosting Framework";
+
+        public const string ScriptSourceConfigRegistryRootPath = RegistryRootPath + @"\ScriptSourceConfig";
+
+        public const string LocalSourceDirectoryKey = "LocalSourceDirectory";
 
         // Ideally, this should move to Data Providers
 

--- a/src/Diagnostics.ScriptHost/Utilities/ScriptHelper.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/ScriptHelper.cs
@@ -1,24 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Immutable;
 
 namespace Diagnostics.ScriptHost.Utilities
 {
-    public class ScriptHelper
+    internal class ScriptHelper
     {
         public static ImmutableArray<string> GetFrameworkReferences() => ImmutableArray.Create(
                 "System.Data",
                 "Diagnostics.DataProviders",
-                "Diagnostics.ScriptHost"
+                "Diagnostics.ScriptHost"    // TODO: Since the models are in script host project right now, we have to pass this reference.
             );
 
         public static ImmutableArray<string> GetFrameworkImports() => ImmutableArray.Create(
                 "System.Data",
                 "System.Threading.Tasks",
                 "Diagnostics.DataProviders",
-                "Diagnostics.ScriptHost.Models"
+                "Diagnostics.ScriptHost.Models",
+                "Diagnostics.ScriptHost.Utilities"  // TODO : just as model, we might want to separate out utilities also that are passed to script.
             );
     }
 }

--- a/src/Diagnostics.ScriptHost/Utilities/UriElements.cs
+++ b/src/Diagnostics.ScriptHost/Utilities/UriElements.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Diagnostics.ScriptHost.Utilities
+﻿namespace Diagnostics.ScriptHost.Utilities
 {
     public class UriElements
     {
@@ -17,5 +12,7 @@ namespace Diagnostics.ScriptHost.Utilities
         public const string Diagnostics = "/diagnostics";
 
         public const string Query = "query";
+        public const string Detectors = "detectors";
+        public const string DetectorResource = "/{detectorId}";
     }
 }

--- a/src/Diagnostics.ScriptHost/appsettings.json
+++ b/src/Diagnostics.ScriptHost/appsettings.json
@@ -11,5 +11,15 @@
         "Default": "Warning"
       }
     }
+  },
+  "ScriptSourceConfig": {
+    "LocalSourceDirectory": ""
+  },
+  "Kusto": {
+    "ClientId": "",
+    "AppKey": "",
+    "DBName": "",
+    "KustoRegionGroupings": "",
+    "KustoClusterNameGroupings": ""
   }
 }

--- a/src/Diagnostics.Scripts/CompilationService/Base/CompilationServiceBase.cs
+++ b/src/Diagnostics.Scripts/CompilationService/Base/CompilationServiceBase.cs
@@ -21,7 +21,7 @@ namespace Diagnostics.Scripts.CompilationService
 
         public Task<ICompilation> GetCompilationAsync()
         {
-            Script<object> script = CSharpScript.Create<object>(_entityMetadata.scriptText, _scriptOptions);
+            Script<object> script = CSharpScript.Create<object>(_entityMetadata.ScriptText, _scriptOptions);
             return CreateCompilationObject(GetScriptCompilation(script));
         }
 

--- a/src/Diagnostics.Scripts/EntityInvoker.cs
+++ b/src/Diagnostics.Scripts/EntityInvoker.cs
@@ -21,10 +21,13 @@ namespace Diagnostics.Scripts
         private ICompilation _compilation;
         private ImmutableArray<Diagnostic> _diagnostics;
         private MethodInfo _entryPointMethodInfo;
+        private ImmutableArray<AttributeData> _attributes;
 
         public bool IsCompilationSuccessful { get; private set; }
 
         public IEnumerable<string> CompilationOutput { get; private set; }
+
+        public ImmutableArray<AttributeData> Attributes => _attributes;
 
         public EntityInvoker(EntityMetadata entityMetadata, ImmutableArray<string> frameworkReferences)
         {
@@ -58,6 +61,7 @@ namespace Diagnostics.Scripts
                     EntityMethodSignature methodSignature = _compilation.GetEntryPointSignature();
                     Assembly assembly = await _compilation.EmitAsync();
                     _entryPointMethodInfo = methodSignature.GetMethod(assembly);
+                    _attributes = methodSignature.Attributes;
                 }
                 catch(Exception ex)
                 {

--- a/src/Diagnostics.Scripts/Models/EntityMetadata.cs
+++ b/src/Diagnostics.Scripts/Models/EntityMetadata.cs
@@ -10,6 +10,16 @@ namespace Diagnostics.Scripts.Models
 
         public string Name;
 
-        public string scriptText;
+        public string ScriptText;
+
+        public EntityMetadata()
+        {
+        }
+
+        public EntityMetadata(string scriptText, EntityType type = EntityType.Signal)
+        {
+            ScriptText = scriptText;
+            Type = type;
+        }
     }
 }

--- a/src/Diagnostics.Tests/DataProviderTests/DataProviderTests.cs
+++ b/src/Diagnostics.Tests/DataProviderTests/DataProviderTests.cs
@@ -24,7 +24,7 @@ namespace Diagnostics.Tests.ScriptsTests
         public async void DataProvders_TestKusto()
         {
             EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata();
-            metadata.scriptText = GetDataProviderScript("TestA");
+            metadata.ScriptText = GetDataProviderScript("TestA");
 
             var configFactory = new MockDataProviderConfigurationFactory();
             var config = configFactory.LoadConfigurations();
@@ -38,8 +38,6 @@ namespace Diagnostics.Tests.ScriptsTests
 
                 Assert.NotNull(result);
             }
-
-
         }
 
         private void PrintDataTable(DataTable dt)

--- a/src/Diagnostics.Tests/Diagnostics.Tests.csproj
+++ b/src/Diagnostics.Tests/Diagnostics.Tests.csproj
@@ -17,7 +17,19 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Diagnostics.DataProviders\Diagnostics.DataProviders.csproj" />
+    <ProjectReference Include="..\Diagnostics.ScriptHost\Diagnostics.ScriptHost.csproj" />
     <ProjectReference Include="..\Diagnostics.Scripts\Diagnostics.Scripts.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="SourceWatcherTests\TestCsxScripts\" />
+  </ItemGroup>
+
+  <Target Name="AfterBuildScript" AfterTargets="Build">
+    <Copy SourceFiles="SourceWatcherTests\LocalFileSystemSourceSettings.json" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="SourceWatcherTests\TestCsxScripts\TestFile1.csx" DestinationFolder="$(OutputPath)\TestCsxScripts" ContinueOnError="true" />
+    <Copy SourceFiles="SourceWatcherTests\TestCsxScripts\TestFile2.csx" DestinationFolder="$(OutputPath)\TestCsxScripts" ContinueOnError="true" />
+    <Copy SourceFiles="SourceWatcherTests\TestCsxScripts\TestFile3-CompilationError.csx" DestinationFolder="$(OutputPath)\TestCsxScripts" ContinueOnError="true" />
+  </Target>
 
 </Project>

--- a/src/Diagnostics.Tests/ScriptHostTests/CacheServiceTests.cs
+++ b/src/Diagnostics.Tests/ScriptHostTests/CacheServiceTests.cs
@@ -1,0 +1,65 @@
+﻿using Diagnostics.ScriptHost;
+using Diagnostics.ScriptHost.Models;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Diagnostics.Tests.ScriptHostTests
+{
+    public class CacheServiceTests
+    {
+        private CompilationCache<string, Definition> _cache;
+
+        public CacheServiceTests()
+        {
+            _cache = new CompilationCache<string, Definition>();
+        }
+
+        [Fact]
+        public void TestAddItemToCache()
+        {
+            Definition item = BuildDefinitionAttribute();
+            _cache.AddOrUpdate(item.Id, item);
+            Assert.True(_cache.TryGetValue(item.Id, out Definition itemInCache));
+            Assert.Equal(item, itemInCache);
+        }
+
+        [Fact]
+        public void TestUpdateItemInCache()
+        {
+            Definition item = BuildDefinitionAttribute();
+            _cache.AddOrUpdate(item.Id, item);
+
+            Definition updatedItem = item;
+            updatedItem.Name = "update name";
+            _cache.AddOrUpdate(updatedItem.Id, updatedItem);
+
+            Assert.True(_cache.TryGetValue(item.Id, out Definition itemInCache));
+            Assert.Equal(updatedItem, itemInCache);
+
+            List<Definition> items = _cache.GetAll().ToList();
+            Assert.Single(items);
+        }
+
+        [Fact]
+        public void TestRemoveItemFromCache()
+        {
+            Definition item = BuildDefinitionAttribute();
+            _cache.AddOrUpdate(item.Id, item);
+
+            Assert.True(_cache.RemoveValue(item.Id, out Definition removedItem));
+            Assert.Equal(item, removedItem);
+            Assert.Empty(_cache.GetAll());
+        }
+
+        private Definition BuildDefinitionAttribute()
+        {
+            return new Definition()
+            {
+                Id = "mockId",
+                Name = "mockName",
+                Description = "some description"
+            };
+        }
+    }
+}

--- a/src/Diagnostics.Tests/ScriptHostTests/HostingEnvironment.cs
+++ b/src/Diagnostics.Tests/ScriptHostTests/HostingEnvironment.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Diagnostics.Tests.ScriptHostTests
+{
+    public class HostingEnvironment : IHostingEnvironment
+    {
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; }
+        public string WebRootPath { get; set; }
+        public IFileProvider WebRootFileProvider { get; set; }
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; }
+    }
+
+    public static class HostingEnviromentBuilder
+    {
+        public static IHostingEnvironment BuildMockEnvironment()
+        {
+            return new HostingEnvironment()
+            {
+                EnvironmentName = "mock",
+                ApplicationName = "test",
+                WebRootPath = "//mockpath",
+                ContentRootPath = "//mockpath"
+            };
+        }
+    }
+}

--- a/src/Diagnostics.Tests/ScriptHostTests/TenantIdServiceTests.cs
+++ b/src/Diagnostics.Tests/ScriptHostTests/TenantIdServiceTests.cs
@@ -1,0 +1,57 @@
+﻿using Diagnostics.ScriptHost.DataProviderServices;
+using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Diagnostics.Tests.ScriptHostTests
+{
+    public class TenantIdServiceTests
+    {
+        private IDataSourcesConfigurationService _dataSourceConfigService;
+        private IHostingEnvironment _hostingEnv;
+        private ITenantIdService _tenantIdService;
+        private Random _rnd;
+
+        public TenantIdServiceTests()
+        {
+            _rnd = new Random();
+            _hostingEnv = HostingEnviromentBuilder.BuildMockEnvironment();
+            _dataSourceConfigService = new DataSourcesConfigurationService(_hostingEnv);
+            _tenantIdService = new TenantIdService(_dataSourceConfigService);
+        }
+
+        [Fact]
+        public async void TestGetTenantId()
+        {
+            List<string> tenantIds = await _tenantIdService.GetTenantIdForStamp($"{_rnd.Next()}stamp", DateTime.UtcNow.AddDays(-1), DateTime.UtcNow);
+            Assert.NotNull(tenantIds);
+            Assert.NotEmpty(tenantIds);
+        }
+
+        [Fact]
+        public async void TestTenantIdCache()
+        {
+            string stampName = $"{_rnd.Next()}stamp";
+            DateTime startTime = DateTime.UtcNow.AddDays(-1);
+            DateTime endTime = DateTime.UtcNow;
+
+            List<string> tenantIdsFirstCall = await _tenantIdService.GetTenantIdForStamp(stampName, startTime, endTime);
+            List<string> tenantIdsSecondCall = await _tenantIdService.GetTenantIdForStamp(stampName, startTime, endTime);
+
+            Assert.Equal<List<string>>(tenantIdsFirstCall, tenantIdsSecondCall);
+        }
+
+        [Fact]
+        public async void TestNullStampName()
+        {
+            DateTime startTime = DateTime.UtcNow.AddDays(-1);
+            DateTime endTime = DateTime.UtcNow;
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                List<string> tenantIds = await _tenantIdService.GetTenantIdForStamp(null, startTime, endTime);
+            });
+        }
+    }
+}

--- a/src/Diagnostics.Tests/ScriptsTests/CompilationServiceTests.cs
+++ b/src/Diagnostics.Tests/ScriptsTests/CompilationServiceTests.cs
@@ -29,7 +29,7 @@ namespace Diagnostics.Tests.ScriptsTests
         public async void CompilationService_TestScriptCompilationFailure()
         {
             EntityMetadata metaData = ScriptTestDataHelper.GetRandomMetadata(EntityType.Detector);
-            metaData.scriptText = ScriptTestDataHelper.GetInvalidCsxScript(ScriptErrorType.CompilationError);
+            metaData.ScriptText = ScriptTestDataHelper.GetInvalidCsxScript(ScriptErrorType.CompilationError);
 
             var serviceInstance = CompilationServiceFactory.CreateService(metaData, ScriptOptions.Default);
             ICompilation compilation = await serviceInstance.GetCompilationAsync();
@@ -61,7 +61,7 @@ namespace Diagnostics.Tests.ScriptsTests
             };
 
             var metaData = ScriptTestDataHelper.GetRandomMetadata();
-            metaData.scriptText = ScriptTestDataHelper.GetAttributedEntryPointMethodScript(attr);
+            metaData.ScriptText = ScriptTestDataHelper.GetAttributedEntryPointMethodScript(attr);
 
             var options = ScriptOptions.Default.WithReferences("Diagnostics.Tests").WithImports("Diagnostics.Tests.ScriptsTests");
 
@@ -89,7 +89,7 @@ namespace Diagnostics.Tests.ScriptsTests
         public async void CompilationService_TestDuplicateEntryPoints(ScriptErrorType errorType)
         {
             EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata();
-            metadata.scriptText = ScriptTestDataHelper.GetInvalidCsxScript(errorType);
+            metadata.ScriptText = ScriptTestDataHelper.GetInvalidCsxScript(errorType);
 
             var serviceInstance = CompilationServiceFactory.CreateService(metadata, ScriptOptions.Default);
             ICompilation compilation = await serviceInstance.GetCompilationAsync();

--- a/src/Diagnostics.Tests/ScriptsTests/EntityInvokerTests.cs
+++ b/src/Diagnostics.Tests/ScriptsTests/EntityInvokerTests.cs
@@ -29,7 +29,7 @@ namespace Diagnostics.Tests.ScriptsTests
         public async void EntityInvoker_TestInvokeWithCompilationError(ScriptErrorType errorType)
         {
             EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata();
-            metadata.scriptText = ScriptTestDataHelper.GetInvalidCsxScript(errorType);
+            metadata.ScriptText = ScriptTestDataHelper.GetInvalidCsxScript(errorType);
 
             using (EntityInvoker invoker = new EntityInvoker(metadata, ImmutableArray.Create<string>()))
             {

--- a/src/Diagnostics.Tests/ScriptsTests/ScriptTestDataHelper.cs
+++ b/src/Diagnostics.Tests/ScriptsTests/ScriptTestDataHelper.cs
@@ -12,7 +12,7 @@ namespace Diagnostics.Tests.ScriptsTests
             return new EntityMetadata()
             {
                 Name = "RandomEntity",
-                scriptText = GetNumSqaureScript(),
+                ScriptText = GetNumSqaureScript(),
                 Type = type
             };
         }

--- a/src/Diagnostics.Tests/SourceWatcherTests/LocalFileSystemSourceSettings.json
+++ b/src/Diagnostics.Tests/SourceWatcherTests/LocalFileSystemSourceSettings.json
@@ -1,0 +1,5 @@
+﻿{
+  "ScriptSourceConfig": {
+    "LocalSourceDirectory": "TestCsxScripts"
+  }
+}

--- a/src/Diagnostics.Tests/SourceWatcherTests/LocalFileSystemSourceWatcherServiceTests.cs
+++ b/src/Diagnostics.Tests/SourceWatcherTests/LocalFileSystemSourceWatcherServiceTests.cs
@@ -1,0 +1,50 @@
+﻿using Diagnostics.ScriptHost;
+using Diagnostics.ScriptHost.Models;
+using Diagnostics.ScriptHost.SourceWatcher;
+using Diagnostics.ScriptHost.SourceWatcher.Interfaces;
+using Diagnostics.Scripts;
+using Diagnostics.Tests.ScriptHostTests;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Diagnostics.Tests.SourceWatcherTests
+{
+    public class LocalFileSystemSourceWatcherServiceTests
+    {
+        private IHostingEnvironment _hostingEnvironment;
+        private IConfiguration _configuration;
+        private CompilationCache<string, Tuple<Definition, EntityInvoker>> _compilationCacheService;
+        private ISourceWatcher _localFileSystemSourceWatcherService;
+
+        public LocalFileSystemSourceWatcherServiceTests()
+        {
+            _hostingEnvironment = HostingEnviromentBuilder.BuildMockEnvironment();
+            _compilationCacheService = new CompilationCache<string, Tuple<Definition, EntityInvoker>>();
+
+            ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddJsonFile("LocalFileSystemSourceSettings.json");
+            _configuration = configurationBuilder.Build();
+            _localFileSystemSourceWatcherService = new LocalFileSystemSourceWatcherService(_hostingEnvironment, _configuration, _compilationCacheService);
+        }
+
+        [Fact]
+        public async void TestWatcher()
+        {
+            await _localFileSystemSourceWatcherService.WaitForCompletion();
+            var cacheEntries = _compilationCacheService.GetAll().ToList();
+            Assert.Equal(2, cacheEntries.Count);
+
+            Assert.True(_compilationCacheService.TryGetValue("testfile1", out Tuple<Definition, EntityInvoker> testEntity1));
+            Assert.True(_compilationCacheService.TryGetValue("testfile2", out Tuple<Definition, EntityInvoker> testEntity2));
+            Assert.False(_compilationCacheService.TryGetValue("testfile3", out Tuple<Definition, EntityInvoker> testEntity3));
+
+            Assert.True(testEntity1.Item2.IsCompilationSuccessful);
+            Assert.True(testEntity2.Item2.IsCompilationSuccessful);
+
+            Assert.Equal("Test File 1", testEntity1.Item1.Name);
+        }
+    }
+}

--- a/src/Diagnostics.Tests/SourceWatcherTests/TestCsxScripts/TestFile1.csx
+++ b/src/Diagnostics.Tests/SourceWatcherTests/TestCsxScripts/TestFile1.csx
@@ -1,0 +1,16 @@
+private static string GetQuery(OperationContext cxt)
+{
+    return
+    $@"Sample Kusto Query Here";
+}
+
+[Definition(Id = "testfile1", Name = "Test File 1", Description = "Test File 1")]
+public async static Task<SignalResponse> Run(DataProviders dp, OperationContext cxt, SignalResponse res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+            Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Stamp)
+    });
+
+    return res;
+}

--- a/src/Diagnostics.Tests/SourceWatcherTests/TestCsxScripts/TestFile2.csx
+++ b/src/Diagnostics.Tests/SourceWatcherTests/TestCsxScripts/TestFile2.csx
@@ -1,0 +1,16 @@
+private static string GetQuery(OperationContext cxt)
+{
+    return
+    $@"Sample Kusto Query Here";
+}
+
+[Definition(Id = "testfile2", Name = "Test File 2", Description = "Test File 2")]
+public async static Task<SignalResponse> Run(DataProviders dp, OperationContext cxt, SignalResponse res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+            Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Stamp)
+    });
+
+    return res;
+}

--- a/src/Diagnostics.Tests/SourceWatcherTests/TestCsxScripts/TestFile3-CompilationError.csx
+++ b/src/Diagnostics.Tests/SourceWatcherTests/TestCsxScripts/TestFile3-CompilationError.csx
@@ -1,0 +1,16 @@
+private static string GetQuery(OperationContext cxt)
+{
+    return
+    $@"Sample Kusto Query Here"
+}
+
+[Definition(Id = "testfile3", Name = "Test File 3", Description = "Test File 3")]
+public async static Task<SignalResponse> Run(DataProviders dp, OperationContext cxt, SignalResponse res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+            Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Stamp)
+    });
+
+    return res;
+}


### PR DESCRIPTION
Following Changes:
- List/Get detectors API
- Compilation cache logic
- Local Source watcher for csx scripts
- Tenant Id service to fetch tenant ids and pass it to script
- Unit tests