### PR TITLE
Adding More DAAS Tools and Improving UI for Profiler to enable collecting raw stack traces

### DIFF
--- a/app/availability/availability.routeconfig.ts
+++ b/app/availability/availability.routeconfig.ts
@@ -13,6 +13,9 @@ import { ProfilerToolComponent } from '../shared/components/tools/profiler-tool/
 import { MemoryDumpToolComponent } from '../shared/components/tools/memorydump-tool/memorydump-tool.component';
 import { JavaMemoryDumpToolComponent } from '../shared/components/tools/java-memorydump-tool/java-memorydump-tool.component';
 import { JavaThreadDumpToolComponent } from '../shared/components/tools/java-threaddump-tool/java-threaddump-tool.component';
+import { HttpLogAnalysisToolComponent } from '../shared/components/tools/http-loganalysis-tool/http-loganalysis-tool.component';
+import { PhpProcessAnalyzerToolComponent } from '../shared/components/tools/php-processanalyzer-tool/php-processanalyzer-tool.component';
+import { PhpLogsAnalyzerToolComponent } from '../shared/components/tools/php-logsanalyzer-tool/php-logsanalyzer-tool.component';
 
 const _siteResourceUrl: string = 'subscriptions/:subscriptionid/resourcegroups/:resourcegroup/sites/:sitename';
 const _slotResourceUrl: string = 'subscriptions/:subscriptionid/resourcegroups/:resourcegroup/sites/:sitename/slots/:slot';
@@ -174,16 +177,14 @@ export const AvailabilityAndPerformanceCategoryRouteConfig: Route[] = [
         path: _siteResourceUrl + '/diagnostics/tools/profiler',
         component: ProfilerToolComponent,
         data: {
-            navigationTitle: 'CLR Profiler',
-            cacheComponent: true
+            navigationTitle: 'CLR Profiler'            
         }
     },
     {
         path: _slotResourceUrl + '/diagnostics/tools/profiler',
         component: ProfilerToolComponent,
         data: {
-            navigationTitle: 'CLR Profiler',
-            cacheComponent: true
+            navigationTitle: 'CLR Profiler'
         }
     },
 
@@ -192,16 +193,14 @@ export const AvailabilityAndPerformanceCategoryRouteConfig: Route[] = [
         path: _siteResourceUrl + '/diagnostics/tools/memorydump',
         component: MemoryDumpToolComponent,
         data: {
-            navigationTitle: 'Memory Dump',
-            cacheComponent: true
+            navigationTitle: 'Memory Dump'
         }
     },
     {
         path: _slotResourceUrl + '/diagnostics/tools/memorydump',
         component: MemoryDumpToolComponent,
         data: {
-            navigationTitle: 'Memory Dump',
-            cacheComponent: true
+            navigationTitle: 'Memory Dump'
         }
     },    
     // Java Thread Dump
@@ -209,16 +208,14 @@ export const AvailabilityAndPerformanceCategoryRouteConfig: Route[] = [
         path: _siteResourceUrl + '/diagnostics/tools/javathreaddump',
         component: JavaThreadDumpToolComponent,
         data: {
-            navigationTitle: 'Java Thread Dump',
-            cacheComponent: true
+            navigationTitle: 'Java Thread Dump'
         }
     },
     {
         path: _slotResourceUrl + '/diagnostics/tools/javathreaddump',
         component: JavaThreadDumpToolComponent,
         data: {
-            navigationTitle: 'Java Thread Dump',
-            cacheComponent: true
+            navigationTitle: 'Java Thread Dump'
         }
     },
     // Java Memory Dump
@@ -226,16 +223,61 @@ export const AvailabilityAndPerformanceCategoryRouteConfig: Route[] = [
         path: _siteResourceUrl + '/diagnostics/tools/javamemorydump',
         component: JavaMemoryDumpToolComponent,
         data: {
-            navigationTitle: 'Java Memory Dump',
-            cacheComponent: true
+            navigationTitle: 'Java Memory Dump'
         }
     },
     {
         path: _slotResourceUrl + '/diagnostics/tools/javamemorydump',
         component: JavaMemoryDumpToolComponent,
         data: {
-            navigationTitle: 'Java Memory Dump',
-            cacheComponent: true
+            navigationTitle: 'Java Memory Dump'
+        }
+    },
+    
+    // HTTP Log Analyzer 
+    {
+        path: _siteResourceUrl + '/diagnostics/tools/httploganalyzer',
+        component: HttpLogAnalysisToolComponent,
+        data: {
+            navigationTitle: 'HTTP Log Analyzer'
+        }
+    },
+    {
+        path: _slotResourceUrl + '/diagnostics/tools/httploganalyzer',
+        component: HttpLogAnalysisToolComponent,
+        data: {
+            navigationTitle: 'HTTP Log Analyzer'
+        }
+    },
+    // PHP Log Analyzer 
+    {
+        path: _siteResourceUrl + '/diagnostics/tools/phploganalyzer',
+        component: PhpLogsAnalyzerToolComponent,
+        data: {
+            navigationTitle: 'PHP Log Analyzer'
+        }
+    },
+    {
+        path: _slotResourceUrl + '/diagnostics/tools/phploganalyzer',
+        component: PhpLogsAnalyzerToolComponent,
+        data: {
+            navigationTitle: 'PHP Log Analyzer'
+        }
+    }
+    ,
+    // PHP Process Analyzer 
+    {
+        path: _siteResourceUrl + '/diagnostics/tools/phpprocessanalyzer',
+        component: PhpProcessAnalyzerToolComponent,
+        data: {
+            navigationTitle: 'PHP Process Analyzer'
+        }
+    },
+    {
+        path: _slotResourceUrl + '/diagnostics/tools/phpprocessanalyzer',
+        component: PhpProcessAnalyzerToolComponent,
+        data: {
+            navigationTitle: 'PHP Process Analyzer'
         }
     }
 

--- a/app/shared/components/daas-sessions/daas-sessions.component.html
+++ b/app/shared/components/daas-sessions/daas-sessions.component.html
@@ -1,4 +1,4 @@
-<div class="header2">Last 5 {{DiagnoserHeading}}</div>
+<div *ngIf="supportedTier" class="header2">Last 5 {{DiagnoserHeading}}</div>
     <div>
         <div class="col" *ngIf="checkingExistingSessions">
             <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
@@ -21,7 +21,7 @@
                         <td>{{ session.StartTime }} (UTC)</td>
                         <td>
                             <div *ngFor="let diagnoser of session.DiagnoserSessions">
-                                <div *ngIf="diagnoser.Name === SessionType">
+                                <div *ngIf="diagnoser.Name.startsWith(SessionType)">
                                     <ul *ngIf="diagnoser.Reports.length > 0" style="list-style: none;">
                                         <li *ngFor="let report of diagnoser.Reports">
                                             {{ getInstanceNameFromReport(report.FileName) }}

--- a/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Session } from '../../models/daas';
-import { WindowService } from '../../services/index';
+import { WindowService, ServerFarmDataService } from '../../services/index';
 
 @Component({
     selector: 'daas-sessions',
@@ -17,14 +17,25 @@ export class DaasSessionsComponent {
     @Input() public scmPath: string;
 
     DiagnoserHeading:string;
+    supportedTier:boolean = false;
 
-    constructor(private _windowService: WindowService) {
+    constructor(private _windowService: WindowService, private _serverFarmService: ServerFarmDataService) {
+        this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
+            if (serverFarm) {
+                if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier === "Basic"  || serverFarm.sku.tier === "Premium")
+                {
+                    this.supportedTier = true;
+                }
+            }
+        }, error => {
+        //TODO: handle error
+        })
         
     }
 
     ngOnInit(): void {
 
-        if (this.SessionType === "CLR Profiler")
+        if (this.SessionType.startsWith("CLR Profiler"))
         {
             this.DiagnoserHeading = "profiling sessions";
         }
@@ -40,7 +51,7 @@ export class DaasSessionsComponent {
 
     getInstanceNameFromReport(reportName: string): string {
 
-        if (this.SessionType !="CLR Profiler")
+        if (!this.SessionType.startsWith("CLR Profiler"))
         {
             return reportName;
         }

--- a/app/shared/components/daas/daas.component.html
+++ b/app/shared/components/daas/daas.component.html
@@ -7,7 +7,7 @@
                     <b>{{siteToBeDiagnosed.siteName}}</b>
                 </td>
             </tr>
-            <tr *ngIf="!error">
+            <tr *ngIf="!error && !foundDiagnoserWarnings">
                 <td>
                     Instance(s):
                 </td>
@@ -29,8 +29,12 @@
                 <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
                 Retrieving instances...
             </div>
+            <div class="col" *ngIf="retrievingDiagnosers && !retrievingInstances && !checkingExistingSessions">
+                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                Retrieving Diagnoser settings...
+            </div>
 
-            <button [disabled]="sessionInProgress || checkingExistingSessions || retrievingInstances || retrievingInstancesFailed" [hidden]="SessionCompleted"
+            <button [disabled]="sessionInProgress || checkingExistingSessions || retrievingInstances || retrievingInstancesFailed || retrievingDiagnosers || foundDiagnoserWarnings" [hidden]="SessionCompleted"
                 class="btn btn-primary" (click)="collectDiagnoserData()">Collect {{ DiagnoserName }}</button>
         </div>
 
@@ -52,6 +56,12 @@
         </div>
         <div *ngIf="error.code != 'GatewayTimeout'">
             <strong>Error</strong> - {{ error.message }}
+        </div>
+    </div>
+
+    <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="foundDiagnoserWarnings">
+        <div>
+            <strong>Warning</strong> - {{ diagnoserWarning }}
         </div>
     </div>
 </div>

--- a/app/shared/components/daas/daas.component.html
+++ b/app/shared/components/daas/daas.component.html
@@ -1,82 +1,91 @@
-<div class="action-box" *ngIf="siteToBeDiagnosed">
-    <div>
-        <table style="border:none">
-            <tr>
-                <td>App: </td>
-                <td class="highlight-blue">
-                    <b>{{siteToBeDiagnosed.siteName}}</b>
-                </td>
-            </tr>
-            <tr *ngIf="!error && !foundDiagnoserWarnings">
-                <td>
-                    Instance(s):
-                </td>
-                <td class="highlight-blue">
-                    <div *ngFor="let instance of InstancesSelected;let i = index">
-                        <input type="checkbox" value="{{ instance.InstanceName }}" name="{{ instance.InstanceName }}" [(ngModel)]="InstancesSelected[i].Selected"
-                        /> {{ instance.InstanceName}}
-                    </div>
-                </td>
-            </tr>
-        </table>
-
-        <div style="text-align:right">
-            <div class="col" *ngIf="checkingExistingSessions">
-                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                Checking existing sessions...
-            </div>
-            <div class="col" *ngIf="retrievingInstances">
-                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                Retrieving instances...
-            </div>
-            <div class="col" *ngIf="retrievingDiagnosers && !retrievingInstances && !checkingExistingSessions">
-                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                Retrieving Diagnoser settings...
-            </div>
-
-            <button [disabled]="sessionInProgress || checkingExistingSessions || retrievingInstances || retrievingInstancesFailed || retrievingDiagnosers || foundDiagnoserWarnings" [hidden]="SessionCompleted"
-                class="btn btn-primary" (click)="collectDiagnoserData()">Collect {{ DiagnoserName }}</button>
-        </div>
-
-        <div class="status-box" *ngIf="sessionInProgress">
-            <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
-                <option *ngFor="let instancestatus of InstancesStatus | mapValues" value={{instancestatus.key}}>
-                    {{instancestatus.key}}
-                </option>
-            </select>
-
-            <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps" [WizardStepStatus]= "WizardStepStatus"></step-wizard>
-
-        </div>
-    </div>
-    <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="error">
-        <div *ngIf="error.code === 'GatewayTimeout'">
-            <strong>Error</strong> - Failed to fetch instances for the Web App. The instance may fail to respond to any diagnostic
-            calls under high CPU situations. Please retry this investigation after some time.
-        </div>
-        <div *ngIf="error.code != 'GatewayTimeout'">
-            <strong>Error</strong> - {{ error.message }}
-        </div>
-    </div>
-
-    <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="foundDiagnoserWarnings">
+<div *ngIf="!supportedTier">
+    <div class="focus-box focus-box-warning" style="margin-top:20px">
         <div>
-            <strong>Warning</strong> - {{ diagnoserWarning }}
+            <strong>Error</strong> - This tool is supported only on Dedicated SKU's
         </div>
     </div>
 </div>
+<div *ngIf="supportedTier">
+    <div class="action-box" *ngIf="siteToBeDiagnosed">
+        <div>
+            <table style="border:none">
+                <tr>
+                    <td>App: </td>
+                    <td class="highlight-blue">
+                        <b>{{siteToBeDiagnosed.siteName}}</b>
+                    </td>
+                </tr>
+                <tr *ngIf="!error && !foundDiagnoserWarnings">
+                    <td>
+                        Instance(s):
+                    </td>
+                    <td class="highlight-blue">
+                        <div *ngFor="let instance of InstancesSelected;let i = index">
+                            <input type="checkbox" value="{{ instance.InstanceName }}" name="{{ instance.InstanceName }}" [(ngModel)]="InstancesSelected[i].Selected"
+                            /> {{ instance.InstanceName}}
+                        </div>
+                    </td>
+                </tr>
+            </table>
 
-<div class="status-box" *ngIf="Reports?.length > 0">
-    <table class="table table-hover">
-        <tbody>
-            <tr *ngFor="let report of Reports">
-                <td>
-                    {{ report.FileName }}
-                </td>
-                <td>
-                    <a (click)="openReport(report.RelativePath)" class="btn btn-primary">Open Report</a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+            <div style="text-align:right">
+                <div class="col" *ngIf="checkingExistingSessions">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Checking existing sessions...
+                </div>
+                <div class="col" *ngIf="retrievingInstances">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Retrieving instances...
+                </div>
+                <div class="col" *ngIf="retrievingDiagnosers && !retrievingInstances && !checkingExistingSessions">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Retrieving Diagnoser settings...
+                </div>
+
+                <button [disabled]="sessionInProgress || checkingExistingSessions || retrievingInstances || retrievingInstancesFailed || retrievingDiagnosers || foundDiagnoserWarnings"
+                    [hidden]="SessionCompleted" class="btn btn-primary" (click)="collectDiagnoserData()">Collect {{ DiagnoserName }}</button>
+            </div>
+
+            <div class="status-box" *ngIf="sessionInProgress">
+                <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
+                    <option *ngFor="let instancestatus of InstancesStatus | mapValues" value={{instancestatus.key}}>
+                        {{instancestatus.key}}
+                    </option>
+                </select>
+
+                <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps" [WizardStepStatus]="WizardStepStatus"></step-wizard>
+
+            </div>
+        </div>
+        <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="error">
+            <div *ngIf="error.code === 'GatewayTimeout'">
+                <strong>Error</strong> - Failed to fetch instances for the Web App. The instance may fail to respond to any diagnostic
+                calls under high CPU situations. Please retry this investigation after some time.
+            </div>
+            <div *ngIf="error.code != 'GatewayTimeout'">
+                <strong>Error</strong> - {{ error.message }}
+            </div>
+        </div>
+
+        <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="foundDiagnoserWarnings">
+            <div>
+                <strong>Warning</strong> - {{ diagnoserWarning }}
+            </div>
+        </div>
+    </div>
+
+    <div class="status-box" *ngIf="Reports?.length > 0">
+        <table class="table table-hover">
+            <tbody>
+                <tr *ngFor="let report of Reports">
+                    <td>
+                        {{ report.FileName }}
+                    </td>
+                    <td>
+                        <a (click)="openReport(report.RelativePath)" class="btn btn-primary">Open Report</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 </div>

--- a/app/shared/components/daas/daas.component.ts
+++ b/app/shared/components/daas/daas.component.ts
@@ -3,8 +3,9 @@ import { SiteDaasInfo } from '../../models/solution-metadata';
 import { Session, Diagnoser, Report, DiagnoserDefinition } from '../../models/daas';
 import { Subscription } from 'rxjs';
 import { StepWizardSingleStep } from '../../models/step-wizard-single-step';
-import { SiteService, DaasService, WindowService, AvailabilityLoggingService } from '../../services';
+import { SiteService, DaasService, WindowService, AvailabilityLoggingService, ServerFarmDataService } from '../../services';
 import { Observable } from 'rxjs/Observable';
+import { ServerFarm } from '../../models/server-farm';
 
 
 class InstanceSelection {
@@ -51,14 +52,30 @@ export class DaasComponent implements OnInit, OnDestroy {
     retrievingInstancesFailed: boolean = false;
     foundDiagnoserWarnings:boolean = false;
     retrievingDiagnosers: boolean = false;
-
+    
+    supportedTier:boolean = false;
     diagnoserWarning: string = "";
 
-    constructor(private _siteService: SiteService, private _daasService: DaasService, private _windowService: WindowService, private _logger: AvailabilityLoggingService) {
+    constructor(private _serverFarmService: ServerFarmDataService, private _siteService: SiteService, private _daasService: DaasService, private _windowService: WindowService, private _logger: AvailabilityLoggingService) {
+        this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
+            if (serverFarm) {
+                if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier === "Basic"  || serverFarm.sku.tier === "Premium")
+                {
+                    this.supportedTier = true;
+                }               
+            }
+        }, error => {
+            //TODO: handle error
+        })
     }
 
     ngOnInit(): void {
 
+        if (!this.supportedTier)
+        {
+            return;
+        }
+        
         this.SessionCompleted = false;
 
         this.retrievingInstances = true;

--- a/app/shared/components/daas/profiler.component.html
+++ b/app/shared/components/daas/profiler.component.html
@@ -1,69 +1,92 @@
-<div class="action-box" *ngIf="siteToBeProfiled">
-    <div>
-        <table style="border:none">
-            <tr>
-                <td>App to be Profiled: </td>
-                <td class="highlight-blue">
-                    <b>{{siteToBeProfiled.siteName}}</b>
-                </td>
-            </tr>
-            <tr *ngIf="!error">
-                <td>
-                    Instance(s):
-                </td>
-                <td class="highlight-blue">
-                    <span *ngFor="let instance of instances; let isLast=last">
-                        {{instance}}{{isLast? '':','}}
-                    </span>
-                </td>
-            </tr>
+<div *ngIf="!supportedTier">
+    <div class="focus-box focus-box-warning" style="margin-top:20px">
+        <div>
+            <strong>Error</strong> - This tool is supported only on Dedicated SKU's
+        </div>
+    </div>
+</div>
+<div *ngIf="supportedTier">
+    <div class="action-box" *ngIf="siteToBeProfiled">
+        <div>
+            <table style="border:none">
+                <tr>
+                    <td>App to be Profiled: </td>
+                    <td class="highlight-blue">
+                        <b>{{siteToBeProfiled.siteName}}</b>
+                    </td>
+                </tr>
+                <tr *ngIf="!error">
+                    <td>
+                        Instance(s):
+                    </td>
+                    <td class="highlight-blue">
+                        <span *ngFor="let instance of instances; let isLast=last">
+                            {{instance}}{{isLast? '':','}}
+                        </span>
+                    </td>
+                </tr>             
+            </table>
+
+            <div style="text-align:right">
+                <div class="col" *ngIf="checkingExistingSessions">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Checking existing sessions...
+                </div>
+                <div class="col" *ngIf="retrievingInstances">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Retrieving instances...
+                </div>
+
+                <button [disabled]="sessionInProgress || checkingExistingSessions || retrievingInstances || retrievingInstancesFailed" [hidden]="SessionCompleted"
+                    class="btn btn-primary" (click)="collectProfilerTrace()">Collect Profiler Trace</button>
+                <div style="margin-top:5px">
+                    <input type="checkbox"  [(ngModel)]="collectStackTraces"/> With thread report
+                    <div class="tool-tip" style="z-index:2">
+                        <i class="fa fa-info-circle" style="color:rgb(84, 143, 255)"></i>
+                        <span class="tool-tip-text">If this option is enabled, then along with the profiler trace, a thread report of all the threads in
+                            the process is also collected at the end of the profiler trace. This is useful espeically if you are troubleshooting totally hung processes or deadlocks or requests taking more than 60 seconds.This will have the effect of pausing your process for a few seconds till the thread dump is generated.
+                            <div style="margin-top:10px">
+                                CAUTION : This option is NOT recommended if you are experiencing high CPU on the instance.
+                            </div>
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="status-box" *ngIf="sessionInProgress">
+                <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
+                    <option *ngFor="let instancestatus of InstancesStatus | mapValues" value={{instancestatus.key}}>
+                        {{instancestatus.key}}
+                    </option>
+                </select>
+                <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps"></step-wizard>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="error">
+        <div *ngIf="error.code === 'GatewayTimeout'">
+            <strong>Error</strong> - Failed to fetch instances for the web app. The instance may fail to respond to any diagnostic
+            calls under high CPU situations. Please retry this investigation after some time.
+        </div>
+        <div *ngIf="error.code != 'GatewayTimeout'">
+            <strong>Error</strong> - {{ error.message }}
+        </div>
+    </div>
+
+    <div class="status-box" *ngIf="Reports?.length > 0">
+        <table class="table table-hover">
+            <tbody>
+                <tr *ngFor="let report of Reports">
+                    <td>
+                        {{ report.FileName }}
+                    </td>
+                    <td>
+                        <a (click)="openReport(report.RelativePath)" class="btn btn-primary">Open Report</a>
+                    </td>
+                </tr>
+            </tbody>
         </table>
-
-        <div style="text-align:right">
-            <div class="col" *ngIf="checkingExistingSessions">
-                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                Checking existing sessions...
-            </div>
-            <div class="col" *ngIf="retrievingInstances">
-                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                Retrieving instances...
-            </div>
-
-            <button [disabled]="sessionInProgress || checkingExistingSessions || retrievingInstances || retrievingInstancesFailed" [hidden]="SessionCompleted" class="btn btn-primary" (click)="collectProfilerTrace()">Collect Profiler Trace</button>
-        </div>
-
-        <div class="status-box" *ngIf="sessionInProgress">
-            <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
-                <option *ngFor="let instancestatus of InstancesStatus | mapValues" value={{instancestatus.key}}>
-                    {{instancestatus.key}}
-                </option>
-            </select>
-            <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps"></step-wizard>
-        </div>
     </div>
-
-</div>
-
-<div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="error">
-    <div *ngIf="error.code === 'GatewayTimeout'">
-        <strong>Error</strong> - Failed to fetch instances for the web app. The instance may fail to respond to any diagnostic calls under high CPU situations. Please retry this investigation after some time.
-    </div>
-    <div *ngIf="error.code != 'GatewayTimeout'">
-        <strong>Error</strong> - {{ error.message }}
-    </div>
-</div>
-
-<div class="status-box" *ngIf="Reports?.length > 0">
-    <table class="table table-hover">
-        <tbody>
-            <tr *ngFor="let report of Reports">
-                <td>
-                    {{ report.FileName }}
-                </td>
-                <td>
-                    <a (click)="openReport(report.RelativePath)" class="btn btn-primary">Open Report</a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
 </div>

--- a/app/shared/components/tools/http-loganalysis-tool/http-loganalysis-tool.component.html
+++ b/app/shared/components/tools/http-loganalysis-tool/http-loganalysis-tool.component.html
@@ -1,0 +1,19 @@
+<div class="container">
+    <div class="header1">{{ title }}</div>
+    <p>{{ description }}</p>
+    <div class="wizardcontainer">
+
+        <daas [scmPath]="scmPath" [siteToBeDiagnosed]="siteToBeDiagnosed" [DiagnoserName]="DiagnoserName" (checkingExistingSessionsEvent)="updateCheckingExistingSessions($event)"
+            (SessionsEvent)="updateSessions($event)">
+        </daas>
+    </div>
+
+    <div class="header2">What you should know before running HTTP Log Analyzer</div>
+    <ul>
+        <li *ngFor="let statement of thingsToKnowBefore">{{statement}}</li>
+    </ul>
+
+    <div class="sessions">
+        <daas-sessions SessionType="Http Logs" [scmPath]="scmPath" [checkingExistingSessions]="checkingExistingSessions" [Sessions]="Sessions"></daas-sessions>
+    </div>
+</div>

--- a/app/shared/components/tools/http-loganalysis-tool/http-loganalysis-tool.component.ts
+++ b/app/shared/components/tools/http-loganalysis-tool/http-loganalysis-tool.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { SiteDaasInfo } from '../../../models/solution-metadata';
+import { Session } from '../../../models/daas';
+import { SiteService, DaasService, WindowService, AvailabilityLoggingService } from '../../../services';
+import { SiteInfoMetaData } from '../../../models/site';
+import { DaasBaseComponent } from '../daas-base/daas-base.component';
+
+@Component({
+    templateUrl: 'http-loganalysis-tool.component.html',
+    styleUrls: ['../styles/daasstyles.css']
+})
+export class HttpLogAnalysisToolComponent extends DaasBaseComponent implements OnInit {
+
+    title: string = "Collect and Analyzes HTTP logs";
+    description: string = "If your Web App is experiencing heavy traffic, you can run this tool to identify slowest requests, client IP addresses and HTTP status codes returned by the App.";
+    
+    thingsToKnowBefore: string[] = [
+        "This tool parses HTTP logs persisted to File-System and HTTP Logging must be enabled for this tool to work.",
+        "Analyzing IIS logs is a CPU-intensive operation, so you should run it only if the App has enough CPU resources.",    
+        "Your App will not be restarted as a result of collecting and analyzing IIS logs.",
+        "HTTP Log Analysis uses the LogParser tool to analyze IIS logs."
+
+    ]
+    
+    constructor(private _siteServiceLocal: SiteService, private _daasServiceLocal: DaasService, private _windowServiceLocal: WindowService, private _loggerLocal: AvailabilityLoggingService)
+    {
+        super(_siteServiceLocal, _daasServiceLocal, _windowServiceLocal, _loggerLocal);
+    }
+    ngOnInit(): void {
+
+        this.DiagnoserName = "Http Logs";
+        this.scmPath = this._siteServiceLocal.currentSiteStatic.enabledHostNames.find(hostname => hostname.indexOf('.scm.') > 0);
+
+    }
+
+    
+}

--- a/app/shared/components/tools/java-memorydump-tool/java-memorydump-tool.component.ts
+++ b/app/shared/components/tools/java-memorydump-tool/java-memorydump-tool.component.ts
@@ -19,7 +19,7 @@ export class JavaMemoryDumpToolComponent extends DaasBaseComponent implements On
         "Collecting a jMap memory dump will freeze the process until the memory dump is collected so process cannot serve any requests during this time.",
         "jMap takes a signinficantly long time (in matter of minutes) to dump the JVM heap and this time can go significantly high if the memory consumption is high.",
         "Memory dumps are collected for all the Java process (java.exe) running on the instance.",        
-        "Your WebApp will not be restarted as a result of collecting the Java Memory dump"
+        "Your App will not be restarted as a result of collecting the Java Memory dump"
     ]
     
     constructor(private _siteServiceLocal: SiteService, private _daasServiceLocal: DaasService, private _windowServiceLocal: WindowService, private _loggerLocal: AvailabilityLoggingService)

--- a/app/shared/components/tools/java-threaddump-tool/java-threaddump-tool.component.ts
+++ b/app/shared/components/tools/java-threaddump-tool/java-threaddump-tool.component.ts
@@ -18,7 +18,7 @@ export class JavaThreadDumpToolComponent extends DaasBaseComponent implements On
         "Collecting a jStack log will freeze the process until the jStack log is collected so process cannot serve any requests during the time jStack is running.",
         "jStack logs are collected for all the Java process (java.exe) running on the instance.",
         "jStack takes a few seconds to run but if there are many threads, it can take slightly longer to collect this data.",
-        "Your WebApp will not be restarted as a result of collecting the jStack logs."
+        "Your App will not be restarted as a result of collecting the jStack logs."
     ]
     
     constructor(private _siteServiceLocal: SiteService, private _daasServiceLocal: DaasService, private _windowServiceLocal: WindowService, private _loggerLocal: AvailabilityLoggingService)

--- a/app/shared/components/tools/memorydump-tool/memorydump-tool.component.ts
+++ b/app/shared/components/tools/memorydump-tool/memorydump-tool.component.ts
@@ -18,7 +18,7 @@ export class MemoryDumpToolComponent extends DaasBaseComponent implements OnInit
         "Collecting a memory dump freezes process until dump generation finishes so process cannot serve any requests during this time.",
         "Dumps are collected for the worker process (w3wp.exe) and child processes of the worker process.",
         "Size of the memory dump is directly proportional to the process size, so processes consuming more memory will take longer to be dumped.",
-        "Your WebApp will not be restarted as a result of collecting the memory dump."
+        "Your App will not be restarted as a result of collecting the memory dump."
     ]
     
     constructor(private _siteServiceLocal: SiteService, private _daasServiceLocal: DaasService, private _windowServiceLocal: WindowService, private _loggerLocal: AvailabilityLoggingService)

--- a/app/shared/components/tools/php-logsanalyzer-tool/php-logsanalyzer-tool.component.html
+++ b/app/shared/components/tools/php-logsanalyzer-tool/php-logsanalyzer-tool.component.html
@@ -1,0 +1,19 @@
+<div class="container">
+    <div class="header1">{{ title }}</div>
+    <p>{{ description }}</p>
+    <div class="wizardcontainer">
+
+        <daas [scmPath]="scmPath" [siteToBeDiagnosed]="siteToBeDiagnosed" [DiagnoserName]="DiagnoserName" (checkingExistingSessionsEvent)="updateCheckingExistingSessions($event)"
+            (SessionsEvent)="updateSessions($event)">
+        </daas>
+    </div>
+
+    <div class="header2">What you should know before running PHP Log Analyzer</div>
+    <ul>
+        <li *ngFor="let statement of thingsToKnowBefore">{{statement}}</li>
+    </ul>
+
+    <div class="sessions">
+        <daas-sessions SessionType="PHP Error Logs" [scmPath]="scmPath" [checkingExistingSessions]="checkingExistingSessions" [Sessions]="Sessions"></daas-sessions>
+    </div>
+</div>

--- a/app/shared/components/tools/php-logsanalyzer-tool/php-logsanalyzer-tool.component.ts
+++ b/app/shared/components/tools/php-logsanalyzer-tool/php-logsanalyzer-tool.component.ts
@@ -1,0 +1,35 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { SiteDaasInfo } from '../../../models/solution-metadata';
+import { Session } from '../../../models/daas';
+import { SiteService, DaasService, WindowService, AvailabilityLoggingService } from '../../../services';
+import { SiteInfoMetaData } from '../../../models/site';
+import { DaasBaseComponent } from '../daas-base/daas-base.component';
+
+@Component({
+    templateUrl: 'php-logsanalyzer-tool.component.html',
+    styleUrls: ['../styles/daasstyles.css']
+})
+export class PhpLogsAnalyzerToolComponent extends DaasBaseComponent implements OnInit {
+
+    title: string = "Collect and Analyze PHP error logs";
+    description: string = "This tool analyzes PHP logs for your App and generates a report filtering out errors and warnings.";
+    
+    thingsToKnowBefore: string[] = [        
+        "It will only work if PHP Logging is enabled for your Web App.",
+        "Your Web App will not be restarted while running this tool."
+
+    ]
+    
+    constructor(private _siteServiceLocal: SiteService, private _daasServiceLocal: DaasService, private _windowServiceLocal: WindowService, private _loggerLocal: AvailabilityLoggingService)
+    {
+        super(_siteServiceLocal, _daasServiceLocal, _windowServiceLocal, _loggerLocal);
+    }
+    ngOnInit(): void {
+
+        this.DiagnoserName = "PHP Error Logs";
+        this.scmPath = this._siteServiceLocal.currentSiteStatic.enabledHostNames.find(hostname => hostname.indexOf('.scm.') > 0);
+
+    }
+
+    
+}

--- a/app/shared/components/tools/php-processanalyzer-tool/php-processanalyzer-tool.component.html
+++ b/app/shared/components/tools/php-processanalyzer-tool/php-processanalyzer-tool.component.html
@@ -1,0 +1,19 @@
+<div class="container">
+    <div class="header1">{{ title }}</div>
+    <p>{{ description }}</p>
+    <div class="wizardcontainer">
+
+        <daas [scmPath]="scmPath" [siteToBeDiagnosed]="siteToBeDiagnosed" [DiagnoserName]="DiagnoserName" (checkingExistingSessionsEvent)="updateCheckingExistingSessions($event)"
+            (SessionsEvent)="updateSessions($event)">
+        </daas>
+    </div>
+
+    <div class="header2">What you should know before running PHP Process Analyzer</div>
+    <ul>
+        <li *ngFor="let statement of thingsToKnowBefore">{{statement}}</li>
+    </ul>
+
+    <div class="sessions">
+        <daas-sessions SessionType="PHP Process Report" [scmPath]="scmPath" [checkingExistingSessions]="checkingExistingSessions" [Sessions]="Sessions"></daas-sessions>
+    </div>
+</div>

--- a/app/shared/components/tools/php-processanalyzer-tool/php-processanalyzer-tool.component.ts
+++ b/app/shared/components/tools/php-processanalyzer-tool/php-processanalyzer-tool.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { SiteDaasInfo } from '../../../models/solution-metadata';
+import { Session } from '../../../models/daas';
+import { SiteService, DaasService, WindowService, AvailabilityLoggingService } from '../../../services';
+import { SiteInfoMetaData } from '../../../models/site';
+import { DaasBaseComponent } from '../daas-base/daas-base.component';
+
+@Component({
+    templateUrl: 'php-processanalyzer-tool.component.html',
+    styleUrls: ['../styles/daasstyles.css']
+})
+export class PhpProcessAnalyzerToolComponent extends DaasBaseComponent implements OnInit {
+
+    title: string = "Collect a PHP Process and Thread report";
+    description: string = "If your PHP Application is performing slow, you can run this tool to take a memory dump of the PHP processes and analyze PHP thread callstacks.";
+    
+    thingsToKnowBefore: string[] = [
+        "A memory dump of all the PHP processes will be collected and this will pause the process for the duration the memory dump is being collected.",
+        "If the PHP application is consuming a lot of memory, it will take longer time to take a dump and during this time the process cannot serve any active requests.",
+        "After the analysis is component a report with all the PHP processes and their threads will be displayed.",    
+        "This information is helpful only if your PHP application is performing slowly."
+        
+
+    ]
+    
+    constructor(private _siteServiceLocal: SiteService, private _daasServiceLocal: DaasService, private _windowServiceLocal: WindowService, private _loggerLocal: AvailabilityLoggingService)
+    {
+        super(_siteServiceLocal, _daasServiceLocal, _windowServiceLocal, _loggerLocal);
+    }
+    ngOnInit(): void {
+
+        this.DiagnoserName = "PHP Process Report";
+        this.scmPath = this._siteServiceLocal.currentSiteStatic.enabledHostNames.find(hostname => hostname.indexOf('.scm.') > 0);
+
+    }
+
+    
+}

--- a/app/shared/components/tools/profiler-tool/profiler-tool.component.ts
+++ b/app/shared/components/tools/profiler-tool/profiler-tool.component.ts
@@ -14,10 +14,12 @@ export class ProfilerToolComponent implements OnInit {
     description: string = "If your app is down or performing slow, you can collect a profiling trace to identify the root cause of the issue. Profiling is light weight and is designed for production scenarios.";
 
     thingsToKnowBefore: string[] = [
-        "Once the profiler trace is started, reproduce the issue by browsing to the web app",
+        "Once the profiler trace is started, reproduce the issue by browsing to the web app.",
         "The profiler trace will automatically stop after 60 seconds.",
+        "If thread report option is enabled, then raw stack traces of threads inside the process will be collected as well.",
+        "With thread report option, your App may be paused for a few seconds till all the threads are dumped.", 
         "Your web app will not be restarted as a result of running the profiler.",
-        "A profiler trace will help to identify issues in an ASP.NET application only and ASP.NET core is not yet supported",
+        "A profiler trace will help to identify issues in an ASP.NET application only and ASP.NET core is not yet supported.",
     ]
 
     siteToBeProfiled: SiteDaasInfo    

--- a/app/shared/components/tools/styles/daasstyles.css
+++ b/app/shared/components/tools/styles/daasstyles.css
@@ -15,7 +15,7 @@ td {
 }
 
 .header2 {
-    font-size: 2opx;
+    font-size: 20px;
     padding-top: 10px;
     padding-bottom: 10px;
 }

--- a/app/shared/models/daas.ts
+++ b/app/shared/models/daas.ts
@@ -68,3 +68,9 @@ export class Session
     DiagnoserSessions: Diagnoser[];
     Status: SessionStatus;
 }
+
+export interface DiagnoserDefinition {
+    Name: string;
+    Warnings: string[];
+    Description: string;
+}

--- a/app/shared/services/daas.service.ts
+++ b/app/shared/services/daas.service.ts
@@ -10,15 +10,15 @@ export class DaasService {
 
     public currentSite: SiteDaasInfo;
 
-    constructor(private _armClient: ArmService, private _authService: AuthService, private _http: Http, private _uriElementsService: UriElementsService) {       
+    constructor(private _armClient: ArmService, private _authService: AuthService, private _http: Http, private _uriElementsService: UriElementsService) {
     }
 
     getDaasSessions(site: SiteDaasInfo): Observable<Session[]> {
         let resourceUri: string = this._uriElementsService.getAllDiagnosticsSessionsUrl(site);
-        return <Observable<Session[]>>(this._armClient.getResourceWithoutEnvelope<Session[]>(resourceUri));
+        return <Observable<Session[]>>(this._armClient.getResourceWithoutEnvelope<Session[]>(resourceUri, null, true));
     }
 
-    submitDaasSession(site:SiteDaasInfo, diagnoser:string, Instances:string[]): Observable<string> {
+    submitDaasSession(site: SiteDaasInfo, diagnoser: string, Instances: string[]): Observable<string> {
 
         let session = new Session();
         session.CollectLogsOnly = false;
@@ -30,25 +30,20 @@ export class DaasService {
         session.TimeSpan = "00:02:00";
 
         let resourceUri: string = this._uriElementsService.getDiagnosticsSessionsUrl(site);
-        return <Observable<string>>(this._armClient.postResource(resourceUri, session));
+        return <Observable<string>>(this._armClient.postResource(resourceUri, session, null, true));
     }
-    getDaasSessionsWithDetails(site:SiteDaasInfo): Observable<Session[]> {
+    getDaasSessionsWithDetails(site: SiteDaasInfo): Observable<Session[]> {
         let resourceUri: string = this._uriElementsService.getDiagnosticsSessionsDetailsUrl(site, "all", true);
-        return <Observable<Session[]>>this._armClient.getResourceWithoutEnvelope<Session[]>(resourceUri,null,true);
+        return <Observable<Session[]>>this._armClient.getResourceWithoutEnvelope<Session[]>(resourceUri, null, true);
     }
 
-    getDaasSessionWithDetails(site:SiteDaasInfo, sessionId: string): Observable<Session> {
-        let resourceUri: string = this._uriElementsService.getDiagnosticsSingleSessionUrl(site, sessionId, true);        
-        return <Observable<Session>>this._armClient.getResourceWithoutEnvelope<Session>(resourceUri,null, true);
+    getDaasSessionWithDetails(site: SiteDaasInfo, sessionId: string): Observable<Session> {
+        let resourceUri: string = this._uriElementsService.getDiagnosticsSingleSessionUrl(site, sessionId, true);
+        return <Observable<Session>>this._armClient.getResourceWithoutEnvelope<Session>(resourceUri, null, true);
     }
 
-    getInstances(site:SiteDaasInfo): Observable<string[]> {
+    getInstances(site: SiteDaasInfo): Observable<string[]> {
         let resourceUri: string = this._uriElementsService.getDiagnosticsInstancesUrl(site);
-        return <Observable<string[]>>this._armClient.getResourceWithoutEnvelope<string[]>(resourceUri,null, true);
-    }
-
-    startWebJob(site:SiteDaasInfo,) {
-        let resourceUri: string = this._uriElementsService.getDiagnosticsWebJobStartUrl(site);
-        return this._armClient.postResource(resourceUri, null);
+        return <Observable<string[]>>this._armClient.getResourceWithoutEnvelope<string[]>(resourceUri, null, true);
     }
 }

--- a/app/shared/services/daas.service.ts
+++ b/app/shared/services/daas.service.ts
@@ -3,7 +3,7 @@ import { Http } from '@angular/http';
 import { ArmService, AuthService, UriElementsService } from '../services';
 import { Observable } from 'rxjs/Observable';
 import { SiteDaasInfo } from '../models/solution-metadata';
-import { Session } from '../models/daas';
+import { Session, DiagnoserDefinition } from '../models/daas';
 
 @Injectable()
 export class DaasService {
@@ -45,5 +45,10 @@ export class DaasService {
     getInstances(site: SiteDaasInfo): Observable<string[]> {
         let resourceUri: string = this._uriElementsService.getDiagnosticsInstancesUrl(site);
         return <Observable<string[]>>this._armClient.getResourceWithoutEnvelope<string[]>(resourceUri, null, true);
+    }
+
+    getDiagnosers(site: SiteDaasInfo): Observable<DiagnoserDefinition[]> {
+        let resourceUri: string = this._uriElementsService.getDiagnosticsDiagnosersUrl(site);
+        return <Observable<DiagnoserDefinition[]>>this._armClient.getResourceWithoutEnvelope<DiagnoserDefinition[]>(resourceUri, null, true);
     }
 }

--- a/app/shared/services/urielements.service.ts
+++ b/app/shared/services/urielements.service.ts
@@ -38,8 +38,6 @@ export class UriElementsService {
     private _diagnosticsDiagnosersPath = this._diagnosticsPath + "diagnosers";
     private _diagnosticsInstancesPath = this._diagnosticsPath + "instances";
     private _diagnosticsSingleSessionPath = this._diagnosticsPath + "session/{sessionId}/{details}";
-    private _diagnosticsWebJobStatePath = this._diagnosticsPath + "daaswebjobstate";
-    private _diagnosticsWebJobStartPath = this._diagnosticsPath + "daaswebjobstart";
     
     getDiagnosticsDiagnosersUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsDiagnosersPath;
@@ -66,14 +64,6 @@ export class UriElementsService {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsSingleSessionPath
         .replace("{sessionId}", sessionId)
         .replace("{details}", detailed.toString());
-    };
-
-    getDiagnosticsWebJobStateUrl(site: SiteDaasInfo) {
-        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsWebJobStatePath;
-    };
-
-    getDiagnosticsWebJobStartUrl(site: SiteDaasInfo) {
-        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsWebJobStartPath;
     };
 
     getSiteRestartUrl(subscriptionId: string, resourceGroup: string, siteName: string, slot: string = ''): string {

--- a/app/shared/shared.module.ts
+++ b/app/shared/shared.module.ts
@@ -39,6 +39,9 @@ import { DaasComponent } from './components/daas/daas.component';
 import { MemoryDumpToolComponent } from './components/tools/memorydump-tool/memorydump-tool.component';
 import { JavaMemoryDumpToolComponent } from './components/tools/java-memorydump-tool/java-memorydump-tool.component';
 import { JavaThreadDumpToolComponent } from './components/tools/java-threaddump-tool/java-threaddump-tool.component';
+import { HttpLogAnalysisToolComponent } from './components/tools/http-loganalysis-tool/http-loganalysis-tool.component';
+import { PhpProcessAnalyzerToolComponent } from './components/tools/php-processanalyzer-tool/php-processanalyzer-tool.component';
+import { PhpLogsAnalyzerToolComponent } from './components/tools/php-logsanalyzer-tool/php-logsanalyzer-tool.component';
 
 @NgModule({
     declarations: [
@@ -71,7 +74,10 @@ import { JavaThreadDumpToolComponent } from './components/tools/java-threaddump-
         MemoryDumpToolComponent,
         DaasComponent,
         JavaMemoryDumpToolComponent,
-        JavaThreadDumpToolComponent
+        JavaThreadDumpToolComponent,
+        HttpLogAnalysisToolComponent,
+        PhpProcessAnalyzerToolComponent,
+        PhpLogsAnalyzerToolComponent
     ],
     imports: [
         HttpModule,
@@ -113,7 +119,10 @@ import { JavaThreadDumpToolComponent } from './components/tools/java-threaddump-
         DaasComponent,
         MemoryDumpToolComponent,
         JavaMemoryDumpToolComponent,
-        JavaThreadDumpToolComponent
+        JavaThreadDumpToolComponent,
+        HttpLogAnalysisToolComponent,
+        PhpProcessAnalyzerToolComponent,
+        PhpLogsAnalyzerToolComponent
     ]
 })
 export class SharedModule {

--- a/app/solutions/components/specific-solutions/java-threaddump-solution/java-threaddump-solution.component.ts
+++ b/app/solutions/components/specific-solutions/java-threaddump-solution/java-threaddump-solution.component.ts
@@ -28,7 +28,7 @@ export class JavaThreadDumpSolutionComponent implements SolutionBaseComponent, O
         "Collecting a jStack log will freeze the process until the jStack log is collected so process cannot serve any requests during the time jStack is running.",
         "jStack logs are collected for all the Java process (java.exe) running on the instance.",
         "jStack takes a few seconds to run but if there are many threads, it can take slightly longer to collect this data.",
-        "Your WebApp will not be restarted as a result of collecting the jStack logs."
+        "Your App will not be restarted as a result of collecting the jStack logs."
     ]
 
     siteToBeDiagnosed: SiteDaasInfo;

--- a/app/solutions/components/specific-solutions/memorydump-solution/memorydump-solution.component.ts
+++ b/app/solutions/components/specific-solutions/memorydump-solution/memorydump-solution.component.ts
@@ -29,7 +29,7 @@ export class MemoryDumpSolutionComponent implements SolutionBaseComponent, OnIni
         "Collecting a memory dump freezes process until dump generation finishes so process cannot serve any requests during this time.",
         "Dumps are collected for the worker process (w3wp.exe) and child processes of the worker process.",
         "Size of the memory dump is directly proportional to the process size, so processes consuming more memory will take longer to be dumped.",
-        "Your WebApp will not be restarted as a result of collecting the memory dump."
+        "Your App will not be restarted as a result of collecting the memory dump."
     ]
 
     siteToBeDiagnosed: SiteDaasInfo;

--- a/app/solutions/components/specific-solutions/profiling-solution/profiling-solution.component.ts
+++ b/app/solutions/components/specific-solutions/profiling-solution/profiling-solution.component.ts
@@ -23,6 +23,8 @@ export class ProfilingSolutionComponent implements SolutionBaseComponent, OnInit
     thingsToKnowBefore: string[] = [
         "Once the profiler trace is started, reproduce the issue by browsing to the web app",
         "The profiler trace will automatically stop after 60 seconds.",
+        "If thread report option is enabled, then raw stack traces of threads inside the process will be collected as well.",
+        "With thread report option, your App may be paused for a few seconds till all the threads are dumped.",         
         "Your web app will not be restarted as a result of running the profiler.",
         "A profiler trace will help to identify issues in an ASP.NET application only and ASP.NET core is not yet supported",
     ]


### PR DESCRIPTION
1. Adding PHP Logs, PHP Report tools from DAAS 
2. Leveraging DAAS's feature to validate whether HTTP logs and PHP logs have been enabled or not
3.  Adding support for generating raw thread report in profiler
4. Removing caching for all DAAS components as they are reflecting incorrect data due to cache
5. Ensuring that all the DAAS tools show a warning if they site is not running in Dedicated Tiers


